### PR TITLE
made the spi_display_image function faster

### DIFF
--- a/components/ssd1306/ssd1306.h
+++ b/components/ssd1306/ssd1306.h
@@ -166,6 +166,7 @@ void spi_clock_speed(int speed);
 void spi_master_init(SSD1306_t * dev, int16_t mosi, int16_t sclk, int16_t cs, int16_t dc, int16_t reset);
 void spi_device_add(SSD1306_t * dev, int16_t cs, int16_t dc, int16_t reset);
 bool spi_master_write_byte(spi_device_handle_t SPIHandle, const uint8_t* Data, size_t DataLength );
+bool spi_master_write_commands(SSD1306_t * dev, const uint8_t * Commands, size_t DataLength );
 bool spi_master_write_command(SSD1306_t * dev, uint8_t Command );
 bool spi_master_write_data(SSD1306_t * dev, const uint8_t* Data, size_t DataLength );
 void spi_init(SSD1306_t * dev, int width, int height);


### PR DESCRIPTION
I made the spi_display_image function faster by sending three commands at the same time instead of one by one. I tested this change on my esp32 at 240 MHz. The Benchmark fps went from 417.2 to 518.4. That's a 24 % improvement. There is a lot of overhead in sending a single command. Sending three commands takes roughly the same amount of time. By combining the three commands needed for changing the column and page I saved a lot of time.

Now there is also a new function called spi_master_write_commands. You can use it to send an array of commands all at once. It can be used to speed up other areas of the driver where sending several commands individually is slowing down updating the screen.