### PR TITLE
making ssd1306_bitmaps faster by only updating segments/pages changed

### DIFF
--- a/components/ssd1306/ssd1306.c
+++ b/components/ssd1306/ssd1306.c
@@ -599,18 +599,18 @@ void ssd1306_bitmaps(SSD1306_t * dev, int xpos, int ypos, uint8_t * bitmap, int 
 	_ssd1306_bitmaps(dev, xpos, ypos, bitmap, width, height, invert);
 	
 	// Calculate the range of pages and segments to update
-    int start_page = ypos / 8;
-    int end_page = (ypos + height - 1) / 8;
-    int start_seg = xpos;
-    int end_seg = xpos + width - 1;
+	int start_page = ypos / 8;
+	int end_page = (ypos + height - 1) / 8;
+	int start_seg = xpos;
+	int end_seg = xpos + width - 1;
 
-    // Update only the modified pages and segments
-    for (int page = start_page; page <= end_page; page++) {
-        int seg_start = (page == start_page) ? start_seg : 0;
-        int seg_end = (page == end_page) ? end_seg : 127;
-        int seg_width = seg_end - seg_start + 1;
-        ssd1306_display_image(dev, page, seg_start, &dev->_page[page]._segs[seg_start], seg_width);
-    }
+	// Update only the modified pages and segments
+	for (int page = start_page; page <= end_page; page++) {
+		int seg_start = (page == start_page) ? start_seg : 0;
+		int seg_end = (page == end_page) ? end_seg : 127;
+		int seg_width = seg_end - seg_start + 1;
+		ssd1306_display_image(dev, page, seg_start, &dev->_page[page]._segs[seg_start], seg_width);
+	}
 }
 
 

--- a/components/ssd1306/ssd1306.c
+++ b/components/ssd1306/ssd1306.c
@@ -572,7 +572,7 @@ void _ssd1306_bitmaps(SSD1306_t * dev, int xpos, int ypos, uint8_t * bitmap, int
 				_seg++;
 			}
 		}
-		vTaskDelay(1);
+		//vTaskDelay(1);
 		offset = offset + _width;
 		dstBits++;
 		_seg = xpos;
@@ -597,7 +597,20 @@ void _ssd1306_bitmaps(SSD1306_t * dev, int xpos, int ypos, uint8_t * bitmap, int
 void ssd1306_bitmaps(SSD1306_t * dev, int xpos, int ypos, uint8_t * bitmap, int width, int height, bool invert)
 {
 	_ssd1306_bitmaps(dev, xpos, ypos, bitmap, width, height, invert);
-	ssd1306_show_buffer(dev);
+	
+	// Calculate the range of pages and segments to update
+    int start_page = ypos / 8;
+    int end_page = (ypos + height - 1) / 8;
+    int start_seg = xpos;
+    int end_seg = xpos + width - 1;
+
+    // Update only the modified pages and segments
+    for (int page = start_page; page <= end_page; page++) {
+        int seg_start = (page == start_page) ? start_seg : 0;
+        int seg_end = (page == end_page) ? end_seg : 127;
+        int seg_width = seg_end - seg_start + 1;
+        ssd1306_display_image(dev, page, seg_start, &dev->_page[page]._segs[seg_start], seg_width);
+    }
 }
 
 


### PR DESCRIPTION
Changes:
-commented vTaskDelay in _ssd1306_bitmaps 
-removed call to ssd1306_show_buffer within ssd1306_bitmaps and instead now calculate only which pages and segments need to be drawn

Allows for creating very fast animations, especially for small bitmaps.   

Example usage:
for(int frame=0;frame<5;frame++){
	ssd1306_bitmaps(&ssd1306Device, 0, 42, animation[frame], 24, 22, false);
}
This is now so quick you may need to add delays within the for loop.  For my project I'm using this to show a small bubble-pop animation in the bottom left part of the screen.