### PR TITLE
Make the driver component to be public

### DIFF
--- a/components/ssd1306/CMakeLists.txt
+++ b/components/ssd1306/CMakeLists.txt
@@ -13,4 +13,4 @@ else()
 	list(APPEND component_srcs "ssd1306_i2c_legacy.c")
 endif()
 
-idf_component_register(SRCS "${component_srcs}" PRIV_REQUIRES driver INCLUDE_DIRS ".")
+idf_component_register(SRCS "${component_srcs}" REQUIRES driver INCLUDE_DIRS ".")


### PR DESCRIPTION
According to the official requirements for components "REQUIRES should be set to all components whose header files are #included from the public header files of this component."
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-requirements

I described the problem I had in more details here https://github.com/nopnop2002/esp-idf-ssd1306/issues/51. 