### PR TITLE
Fix dependency requirements

### DIFF
--- a/components/ssd1306/CMakeLists.txt
+++ b/components/ssd1306/CMakeLists.txt
@@ -1,16 +1,20 @@
 set(component_srcs "ssd1306.c" "ssd1306_spi.c")
+set(component_deps "")
 
 # get IDF version for comparison
 set(idf_version "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}")
 
-if(idf_version VERSION_GREATER_EQUAL "5.2")
-	if(CONFIG_LEGACY_DRIVER)
-		list(APPEND component_srcs "ssd1306_i2c_legacy.c")
-	else()
-		list(APPEND component_srcs "ssd1306_i2c_new.c")
-	endif()
+if(idf_version VERSION_GREATER_EQUAL "5.3")
+        if(CONFIG_LEGACY_DRIVER)
+                list(APPEND component_deps "driver")
+                list(APPEND component_srcs "ssd1306_i2c_legacy.c")
+        else()
+                list(APPEND component_deps "esp_driver_i2c esp_driver_spi esp_driver_gpio")
+                list(APPEND component_srcs "ssd1306_i2c_new.c")
+        endif()
 else()
-	list(APPEND component_srcs "ssd1306_i2c_legacy.c")
+        list(APPEND component_deps "driver")
+        list(APPEND component_srcs "ssd1306_i2c_legacy.c")
 endif()
 
-idf_component_register(SRCS "${component_srcs}" PRIV_REQUIRES driver INCLUDE_DIRS ".")
+idf_component_register(SRCS "${component_srcs}" REQUIRES "${component_deps}" INCLUDE_DIRS ".")


### PR DESCRIPTION
Using PRIV_REQUIRES instead of REQUIRES won't build with ESP-IDF v5.5.2.

Use the new drivers instead of the monolithic `driver` in new versions when not forcing a legacy build.

Also, it seems like the new drivers were introduced in 5.3 instead of 5.2: https://docs.espressif.com/projects/esp-idf/en/v5.5.2/esp32s2/migration-guides/release-5.x/5.3/peripherals.html. This migration guide is 5.2 -> 5.3 instead of 5.3 -> 5.2.