### PR TITLE
Fixed bug that CONFIG_FLIP option didn't have any effect

### DIFF
--- a/AnimationDemo/main/main.c
+++ b/AnimationDemo/main/main.c
@@ -723,11 +723,8 @@ void app_main(void)
 	spi_master_init(&dev, CONFIG_MOSI_GPIO, CONFIG_SCLK_GPIO, CONFIG_CS_GPIO, CONFIG_DC_GPIO, CONFIG_RESET_GPIO);
 #endif // CONFIG_SPI_INTERFACE
 
-#if 0
 #if CONFIG_FLIP
-	dev._flip = true;
-	ESP_LOGW(TAG, "Flip upside down");
-#endif
+#error "Panel is flipped. This demo cannot be run."
 #endif
 
 #if CONFIG_SSD1306_128x64

--- a/BalloonDemo/main/main.c
+++ b/BalloonDemo/main/main.c
@@ -168,7 +168,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/BdfFontDemo/main/main.c
+++ b/BdfFontDemo/main/main.c
@@ -162,7 +162,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(tag, "Flip upside down");
 #endif
 

--- a/BlinkIconDemo/main/main.c
+++ b/BlinkIconDemo/main/main.c
@@ -196,7 +196,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/CarRaceDemo/main/main.c
+++ b/CarRaceDemo/main/main.c
@@ -228,7 +228,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/CounterDemo/main/main.c
+++ b/CounterDemo/main/main.c
@@ -226,7 +226,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/DeviceAddDemo/main/main.c
+++ b/DeviceAddDemo/main/main.c
@@ -123,7 +123,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(tag, "Flip upside down");
 #endif
 

--- a/FreeTypeDemo/main/main.c
+++ b/FreeTypeDemo/main/main.c
@@ -167,7 +167,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(tag, "Flip upside down");
 #endif
 

--- a/HighwayDemo/main/main.c
+++ b/HighwayDemo/main/main.c
@@ -632,7 +632,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/ImageDemo/main/main.c
+++ b/ImageDemo/main/main.c
@@ -204,7 +204,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/ImageMoveDemo/main/main.c
+++ b/ImageMoveDemo/main/main.c
@@ -454,11 +454,8 @@ void app_main(void)
 	spi_master_init(&dev, CONFIG_MOSI_GPIO, CONFIG_SCLK_GPIO, CONFIG_CS_GPIO, CONFIG_DC_GPIO, CONFIG_RESET_GPIO);
 #endif // CONFIG_SPI_INTERFACE
 
-#if 0
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
-#endif
 #endif
 
 #if CONFIG_SSD1306_128x64

--- a/ImageRotationDemo/main/main.c
+++ b/ImageRotationDemo/main/main.c
@@ -342,11 +342,8 @@ void app_main(void)
 	spi_master_init(&dev, CONFIG_MOSI_GPIO, CONFIG_SCLK_GPIO, CONFIG_CS_GPIO, CONFIG_DC_GPIO, CONFIG_RESET_GPIO);
 #endif // CONFIG_SPI_INTERFACE
 
-#if 0
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
-#endif
 #endif
 
 #if CONFIG_SSD1306_128x64

--- a/ImageScrollDemo/main/main.c
+++ b/ImageScrollDemo/main/main.c
@@ -252,7 +252,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/MeterDemo/main/main.c
+++ b/MeterDemo/main/main.c
@@ -145,7 +145,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/MouseIconDemo/main/main.c
+++ b/MouseIconDemo/main/main.c
@@ -332,7 +332,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/PageDemo/main/main.c
+++ b/PageDemo/main/main.c
@@ -128,7 +128,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/RotaryEncoderDemo/main/main.c
+++ b/RotaryEncoderDemo/main/main.c
@@ -81,7 +81,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/RotaryEncoderDemo2/main/main.c
+++ b/RotaryEncoderDemo2/main/main.c
@@ -455,11 +455,8 @@ void app_main(void)
 	spi_master_init(&dev, CONFIG_MOSI_GPIO, CONFIG_SCLK_GPIO, CONFIG_CS_GPIO, CONFIG_DC_GPIO, CONFIG_RESET_GPIO);
 #endif // CONFIG_SPI_INTERFACE
 
-#if 0
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
-#endif
 #endif
 
 #if CONFIG_SSD1306_128x64

--- a/ScrollCounterDemo/main/main.c
+++ b/ScrollCounterDemo/main/main.c
@@ -276,7 +276,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/TextBoxDemo/main/main.c
+++ b/TextBoxDemo/main/main.c
@@ -53,7 +53,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(tag, "Flip upside down");
 #endif
 

--- a/TextDemo/main/main.c
+++ b/TextDemo/main/main.c
@@ -51,7 +51,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(tag, "Flip upside down");
 #endif
 

--- a/VerticalWritingDemo/main/main.c
+++ b/VerticalWritingDemo/main/main.c
@@ -51,7 +51,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(tag, "Flip upside down");
 #endif
 

--- a/WrapAroundDemo/main/main.c
+++ b/WrapAroundDemo/main/main.c
@@ -49,7 +49,6 @@ void app_main(void)
 #endif // CONFIG_SPI_INTERFACE
 
 #if CONFIG_FLIP
-	dev._flip = true;
 	ESP_LOGW(TAG, "Flip upside down");
 #endif
 

--- a/components/ssd1306/ssd1306_i2c_legacy.c
+++ b/components/ssd1306/ssd1306_i2c_legacy.c
@@ -45,7 +45,11 @@ void i2c_master_init(SSD1306_t * dev, int16_t sda, int16_t scl, int16_t reset)
 	}
 
 	dev->_address = I2C_ADDRESS;
+#if CONFIG_FLIP
+	dev->_flip = true;
+#else
 	dev->_flip = false;
+#endif
 	dev->_i2c_num = I2C_NUM;
 }
 

--- a/components/ssd1306/ssd1306_i2c_new.c
+++ b/components/ssd1306/ssd1306_i2c_new.c
@@ -53,7 +53,11 @@ void i2c_master_init(SSD1306_t * dev, int16_t sda, int16_t scl, int16_t reset)
 	}
 
 	dev->_address = I2C_ADDRESS;
+#if CONFIG_FLIP
+	dev->_flip = true;
+#else
 	dev->_flip = false;
+#endif
 	dev->_i2c_num = I2C_NUM;
 	dev->_i2c_bus_handle = i2c_bus_handle;
 	dev->_i2c_dev_handle = i2c_dev_handle;
@@ -94,7 +98,11 @@ void i2c_device_add(SSD1306_t * dev, i2c_port_t i2c_num, int16_t reset, uint16_t
 	}
 
 	dev->_address = i2c_address;
+#if CONFIG_FLIP
+	dev->_flip = true;
+#else
 	dev->_flip = false;
+#endif
 	dev->_i2c_num = i2c_num;
 	dev->_i2c_dev_handle = i2c_dev_handle;
 }

--- a/components/ssd1306/ssd1306_spi.c
+++ b/components/ssd1306/ssd1306_spi.c
@@ -78,7 +78,11 @@ void spi_master_init(SSD1306_t * dev, int16_t mosi, int16_t sclk, int16_t cs, in
 
 	dev->_dc = dc;
 	dev->_address = SPI_ADDRESS;
+#if CONFIG_FLIP
+	dev->_flip = true;
+#else
 	dev->_flip = false;
+#endif
 	dev->_spi_device_handle = spi_device_handle;
 }
 
@@ -134,7 +138,11 @@ void spi_device_add(SSD1306_t * dev, int16_t cs, int16_t dc, int16_t reset)
 
 	dev->_dc = dc;
 	dev->_address = SPI_ADDRESS;
+#if CONFIG_FLIP
+	dev->_flip = true;
+#else
 	dev->_flip = false;
+#endif
 	dev->_spi_device_handle = spi_device_handle;
 }
 


### PR DESCRIPTION
- No manual code is required to handle the CONFIG_FLIP option; the corresponding field in SSD1306_t is set accordingly
- Updated demo apps for new behavior

Most demos were already adapted for flipped mode, and only minor refactoring was needed. Those that weren't adapted actually work fine in flipped mode, with the only exception of AnimationDemo. The #error directive was added to fail the build if this demo has CONFIG_FLIP enabled.